### PR TITLE
feat(maven): GitHub packages support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npx jsii-release-maven [DIR]
 |`MAVEN_GPG_PRIVATE_KEY` or `MAVEN_GPG_PRIVATE_KEY_FILE` and `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE`|Yes for Maven Central|GPG private key or file that includes it. This is used to sign your Maven packages. See instructions below|
 |`MAVEN_STAGING_PROFILE_ID`|Yes for Maven Central|Maven Central (sonatype) staging profile ID (e.g. 68a05363083174). Staging profile ID can be found **in the URL** of the "Releases" staging profile under "Staging Profiles" in https://oss.sonatype.org (e.g. `https://oss.sonatype.org/#stagingProfiles;11a33451234521`|
 |`MAVEN_ENDPOINT`|No|URL of Nexus repository. Defaults to `https://oss.sonatype.org`|
-|`MAVEN_SERVER_ID`|No|Used in maven settings for credential lookup. Defaults to `ossrh`|
+|`MAVEN_SERVER_ID`|No|Used in maven settings for credential lookup (e.g. use `github` when publishing to GitHub). Defaults to `ossrh` for Maven Central.|
 |`MAVEN_REPOSITORY_URL`|No|Deployment repository when not deploying to Maven Central|
 |`MAVEN_DRYRUN`|No|Set to "true" for a dry run|
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ npx jsii-release-maven [DIR]
 
 |Option|Required|Description|
 |------|--------|-----------|
-|`MAVEN_USERNAME` and `MAVEN_PASSWORD`|Yes|Username and password for Maven Central obtained from Sonatype. You will need to [Create JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa) and then request a [new project](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)|
-|`MAVEN_GPG_PRIVATE_KEY` or `MAVEN_GPG_PRIVATE_KEY_FILE` and `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE`|Yes|GPG private key or file that includes it. This is used to sign your Maven packages. See instructions below|
-|`MAVEN_STAGING_PROFILE_ID`|Yes|Maven Central (sonatype) staging profile ID (e.g. 68a05363083174). Staging profile ID can be found **in the URL** of the "Releases" staging profile under "Staging Profiles" in https://oss.sonatype.org (e.g. `https://oss.sonatype.org/#stagingProfiles;11a33451234521`|
+|`MAVEN_USERNAME` and `MAVEN_PASSWORD`|Yes|Username and password for maven repository. For Maven Central, you will need to [Create JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa) and then request a [new project](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)|
+|`MAVEN_GPG_PRIVATE_KEY` or `MAVEN_GPG_PRIVATE_KEY_FILE` and `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE`|Yes for Maven Central|GPG private key or file that includes it. This is used to sign your Maven packages. See instructions below|
+|`MAVEN_STAGING_PROFILE_ID`|Yes for Maven Central|Maven Central (sonatype) staging profile ID (e.g. 68a05363083174). Staging profile ID can be found **in the URL** of the "Releases" staging profile under "Staging Profiles" in https://oss.sonatype.org (e.g. `https://oss.sonatype.org/#stagingProfiles;11a33451234521`|
+|`MAVEN_ENDPOINT`|No|URL of Nexus repository. Defaults to `https://oss.sonatype.org`|
+|`MAVEN_SERVER_ID`|No|Used in maven settings for credential lookup. Defaults to `ossrh`|
+|`MAVEN_REPOSITORY_URL`|No|Deployment repository when not deploying to Maven Central|
 |`MAVEN_DRYRUN`|No|Set to "true" for a dry run|
 
 **How to create a GPG key?**
@@ -117,6 +120,19 @@ and then assign it to `MAVEN_GPG_PRIVATE_KEY`:
 
 ```console
 $ echo $(cat -e private.pem) | sed 's/\$ /\\n/g' | sed 's/\$$//'
+```
+
+**Publish to GitHub Packages**
+
+An example GitHub Actions publish step:
+```yaml
+- name: Publish package
+  run: npx -p jsii-release jsii-release-maven
+  env:
+    MAVEN_SERVER_ID: github
+    MAVEN_USERNAME: ${{ github.actor }}
+    MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
 ```
 
 ## NuGet

--- a/bin/gpg-workaround.sh
+++ b/bin/gpg-workaround.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+###
+#
+# This script provides a wrapper around gpg used by maven gpg:sign-and-deploy-file.
+# Many versions of gpg require setting pinentry-mode to loopback to prevent prompting.
+# Generally this can be done in a POM file, but jsii-release-maven tries to keep
+# release details self contained. gpgArguments is also not available as a user property.
+# This script follows:
+# https://stackoverflow.com/questions/60417391/pass-in-list-parameter-to-maven-using-the-cli-gpgsign-and-deploy-file 
+#
+###
+
 gpg --pinentry-mode loopback "$@"

--- a/bin/gpg-workaround.sh
+++ b/bin/gpg-workaround.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gpg --pinentry-mode loopback "$@"

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -91,7 +91,7 @@ import_gpg_key() {
     export GPG_TTY=$(tty)
 
 
-    if [ -n "${MAVEN_GPG_PRIVATE_KEY-}" ]; then
+    if [ -n "${MAVEN_GPG_PRIVATE_KEY:-}" ]; then
         MAVEN_GPG_PRIVATE_KEY_FILE="${GNUPGHOME}/private.pem"
         echo -e "${MAVEN_GPG_PRIVATE_KEY}" > ${MAVEN_GPG_PRIVATE_KEY_FILE}
     fi

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -90,7 +90,7 @@ import_gpg_key() {
     export GPG_TTY=$(tty)
 
 
-    if [ -n "${MAVEN_GPG_PRIVATE_KEY}" ]; then
+    if [ -n "${MAVEN_GPG_PRIVATE_KEY-}" ]; then
         MAVEN_GPG_PRIVATE_KEY_FILE="${GNUPGHOME}/private.pem"
         echo -e "${MAVEN_GPG_PRIVATE_KEY}" > ${MAVEN_GPG_PRIVATE_KEY_FILE}
     fi
@@ -129,7 +129,7 @@ create_maven_settings() {
     </server>
     <server>
       <id>gpg.passphrase</id>
-      <passphrase>${env.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE}</passphrase>
+      <passphrase>\${env.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE}</passphrase>
     </server>
   </servers>
 </settings>

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -74,6 +74,10 @@ validate_parameters() {
         validate_non_central_parameters
     fi
 
+    if (${is_signed} && ! ${is_central}); then
+        error "Package signing is currently only supported for Maven Central"
+    fi
+
     if (${is_signed} || ${is_central}); then
         validate_signing_parameters
     fi

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -42,6 +42,7 @@ set -eu # we don't want "pipefail" to implement idempotency
 ###
 
 readonly CENTRAL_SERVER="ossrh"
+scriptdir="$(cd $(dirname $0) && pwd)"
 
 error() { echo "❌ $@"; exit 1; }
 
@@ -165,6 +166,7 @@ sign_artifacts() {
             -DrepositoryId=${server_id}                                             \
             -Dgpg.homedir=${GNUPGHOME}                                              \
             -Dgpg.keyname=0x${gpg_key_id}                                           \
+            -Dgpg.executable="${scriptdir}/gpg-workaround.sh"                       \
             -DpomFile=${pom}                                                        \
             -Dfile=${pom/.pom/.jar}                                                 \
             -Dsources=${pom/.pom/-sources.jar}                                      \

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -16,6 +16,8 @@ set -eu # we don't want "pipefail" to implement idempotency
 # MAVEN_GPG_PRIVATE_KEY_FILE       - GPG private key file (mutually exclusive with MAVEN_GPG_PRIVATE_KEY)
 # MAVEN_GPG_PRIVATE_KEY_PASSPHRASE - The passphrase of the provided key.
 # MAVEN_DRYRUN                     - Set to "true" for a dry run
+# MAVEN_SERVER_ID                  - Used in maven settings for credential lookup
+# MAVEN_REPOSITORY_URL             - Deployment repository when not deploying to maven central
 #
 ###
 
@@ -39,151 +41,180 @@ set -eu # we don't want "pipefail" to implement idempotency
 #
 ###
 
+readonly CENTRAL_SERVER="ossrh"
+
 error() { echo "❌ $@"; exit 1; }
 
-cd "${1:-"dist/java"}"
-
-[ -z "${MAVEN_STAGING_PROFILE_ID:-}" ] && error "MAVEN_STAGING_PROFILE_ID is required"
-[ -z "${MAVEN_USERNAME:-}" ] && error "MAVEN_USERNAME is required"
-[ -z "${MAVEN_PASSWORD:-}" ] && error "MAVEN_PASSWORD is required"
-
-[ -z "${MAVEN_GPG_PRIVATE_KEY_PASSPHRASE:-}" ] && error "MAVEN_GPG_PRIVATE_KEY_PASSPHRASE is required"
-[ -z "${MAVEN_GPG_PRIVATE_KEY_FILE:-}" ] && [ -z "${MAVEN_GPG_PRIVATE_KEY:-}" ] && error "MAVEN_GPG_PRIVATE_KEY_FILE or MAVEN_GPG_PRIVATE_KEY is required"
-[ -n "${MAVEN_GPG_PRIVATE_KEY:-}" ] && [ -n "${MAVEN_GPG_PRIVATE_KEY_FILE:-}" ] && error "Cannot specify both MAVEN_GPG_PRIVATE_KEY and MAVEN_GPG_PRIVATE_KEY_FILE"
-
-if [[ -n "${MAVEN_DRYRUN:-}" ]]; then
-    echo "==========================================="
-    echo "            🏜️ DRY-RUN MODE 🏜️"
-    echo "==========================================="
-    mvn="echo mvn"
-    dry_run=true
-else
-    mvn=mvn
-    dry_run=false
-fi
-
-#---------------------------------------------------------------------------------------------------------------------------------------
-# Import private GPG key
-#---------------------------------------------------------------------------------------------------------------------------------------
-
-echo "Importing GPG key..." >&2
-
-# GnuPG will occasionally bail out with "gpg: <whatever> failed: Inappropriate ioctl for device", the following attempts to fix
-export GNUPGHOME=$(mktemp -d)
-export GPG_TTY=$(tty)
-
-
-if [ -n "${MAVEN_GPG_PRIVATE_KEY}" ]; then
-    MAVEN_GPG_PRIVATE_KEY_FILE="${GNUPGHOME}/private.pem"
-    echo -e "${MAVEN_GPG_PRIVATE_KEY}" > ${MAVEN_GPG_PRIVATE_KEY_FILE}
-fi
-
-gpg --allow-secret-key-import --batch --yes --no-tty --import "${MAVEN_GPG_PRIVATE_KEY_FILE}" || {
-    echo "❌ GPG key import failed"
-    exit 1
+validate_central_parameters() {
+    [[ -z "${MAVEN_STAGING_PROFILE_ID:-}" ]] && error "MAVEN_STAGING_PROFILE_ID is required"
+    return 0
 }
 
-gpg_key_id=$(gpg --list-keys --with-colons | grep pub | cut -d: -f5)
-echo "gpg_key_id=${gpg_key_id}"
+validate_non_central_parameters() {
+    [[ -z "${MAVEN_SERVER_ID:-}" ]] && error "MAVEN_SERVER_ID is required"
+    [[ -z "${MAVEN_REPOSITORY_URL:-}" ]] && error "MAVEN_REPOSITORY_URL is required"
+    return 0
+}
 
-GPG_PASSPHRASE_FROM_STDIN="--passphrase-fd 0"
-if [[ "$(uname)" == "Darwin" ]]; then
-    # On Mac, we must pass this to disable a prompt for
-    # passphrase, but option is not recognized on Linux.
-    GPG_PASSPHRASE_FROM_STDIN="${GPG_PASSPHRASE_FROM_STDIN} --pinentry-mode loopback"
-fi
-export GPG_PASSPHRASE_FROM_STDIN
+validate_signing_parameters() {
+    [[ -z "${MAVEN_GPG_PRIVATE_KEY_PASSPHRASE:-}" ]] && error "MAVEN_GPG_PRIVATE_KEY_PASSPHRASE is required"
+    [[ -z "${MAVEN_GPG_PRIVATE_KEY_FILE:-}" ]] && [[ -z "${MAVEN_GPG_PRIVATE_KEY:-}" ]] && error "MAVEN_GPG_PRIVATE_KEY_FILE or MAVEN_GPG_PRIVATE_KEY is required"
+    [[ -n "${MAVEN_GPG_PRIVATE_KEY:-}" ]] && [[ -n "${MAVEN_GPG_PRIVATE_KEY_FILE:-}" ]] && error "Cannot specify both MAVEN_GPG_PRIVATE_KEY and MAVEN_GPG_PRIVATE_KEY_FILE"
+    return 0
+}
 
-poms="$(find . -name '*.pom')"
-if [ -z "${poms}" ]; then
-    echo "❌ No JARS to publish: no .pom files found under $PWD"
-    exit 1
-fi
+validate_parameters() {
+    [[ -z "${MAVEN_USERNAME:-}" ]] && error "MAVEN_USERNAME is required"
+    [[ -z "${MAVEN_PASSWORD:-}" ]] && error "MAVEN_PASSWORD is required"
 
-echo "📦 Publishing to Maven Central"
-staging=$(mktemp -d)
-workdir=$(mktemp -d)
+    if [[ "${is_central}" == true ]]; then
+        validate_central_parameters
+    else
+        validate_non_central_parameters
+    fi
 
-# Create a settings.xml file with the user+password for maven
-mvn_settings="${workdir}/mvn-settings.xml"
-cat > ${mvn_settings} <<-EOF
+    if [[ "${is_signed}" == true ]] || [[ "${is_central}" == true ]]; then
+        validate_signing_parameters
+    fi
+}
+
+import_gpg_key() {
+    #---------------------------------------------------------------------------------------------------------------------------------------
+    # Import private GPG key
+    #---------------------------------------------------------------------------------------------------------------------------------------
+
+    echo "Importing GPG key..." >&2
+
+    # GnuPG will occasionally bail out with "gpg: <whatever> failed: Inappropriate ioctl for device", the following attempts to fix
+    export GNUPGHOME=$(mktemp -d)
+    export GPG_TTY=$(tty)
+
+
+    if [ -n "${MAVEN_GPG_PRIVATE_KEY}" ]; then
+        MAVEN_GPG_PRIVATE_KEY_FILE="${GNUPGHOME}/private.pem"
+        echo -e "${MAVEN_GPG_PRIVATE_KEY}" > ${MAVEN_GPG_PRIVATE_KEY_FILE}
+    fi
+
+    gpg --allow-secret-key-import --batch --yes --no-tty --import "${MAVEN_GPG_PRIVATE_KEY_FILE}" || {
+        error "GPG key import failed"
+    }
+
+    gpg_key_id=$(gpg --list-keys --with-colons | grep pub | cut -d: -f5)
+    echo "gpg_key_id=${gpg_key_id}"
+
+    GPG_PASSPHRASE_FROM_STDIN="--passphrase-fd 0"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # On Mac, we must pass this to disable a prompt for
+        # passphrase, but option is not recognized on Linux.
+        GPG_PASSPHRASE_FROM_STDIN="${GPG_PASSPHRASE_FROM_STDIN} --pinentry-mode loopback"
+    fi
+    export GPG_PASSPHRASE_FROM_STDIN
+}
+
+create_maven_settings() {
+    # Create a settings.xml file with the user+password for maven
+    mvn_settings="${workdir}/mvn-settings.xml"
+    if [[ "${is_signed}" == true ]]; then
+        cat > ${mvn_settings} <<-EOF
 <?xml version="1.0" encoding="UTF-8" ?>
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
-      <username>${MAVEN_USERNAME}</username>
-      <password>${MAVEN_PASSWORD}</password>
+      <id>${server_id}</id>
+      <username>\${env.MAVEN_USERNAME}</username>
+      <password>\${env.MAVEN_PASSWORD}</password>
+    </server>
+    <server>
+      <id>gpg.passphrase</id>
+      <passphrase>${env.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE}</passphrase>
     </server>
   </servers>
 </settings>
 EOF
+    else
+        cat > ${mvn_settings} <<-EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>${server_id}</id>
+      <username>\${env.MAVEN_USERNAME}</username>
+      <password>\${env.MAVEN_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+    fi
+}
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo " Preparing repository"
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+sign_artifacts() {
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo " Preparing repository"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
-# Sign and stage our artifacts into a local directory
-for pom in ${poms}; do
-    $mvn --settings=${mvn_settings} gpg:sign-and-deploy-file                    \
-        -Durl=file://${staging}                                                 \
-        -DrepositoryId=maven-central                                            \
-        -Dgpg.homedir=${GNUPGHOME}                                              \
-        -Dgpg.keyname=0x${gpg_key_id}                                           \
-        -Dgpg.passphrase=${MAVEN_GPG_PRIVATE_KEY_PASSPHRASE}                    \
-        -DpomFile=${pom}                                                        \
-        -Dfile=${pom/.pom/.jar}                                                 \
-        -Dsources=${pom/.pom/-sources.jar}                                      \
-        -Djavadoc=${pom/.pom/-javadoc.jar}
-done
+    # Sign and stage our artifacts into a local directory
+    for pom in ${poms}; do
+        $mvn --settings=${mvn_settings} gpg:sign-and-deploy-file                    \
+            -Durl=file://${staging}                                                 \
+            -DrepositoryId=${server_id}                                             \
+            -Dgpg.homedir=${GNUPGHOME}                                              \
+            -Dgpg.keyname=0x${gpg_key_id}                                           \
+            -DpomFile=${pom}                                                        \
+            -Dfile=${pom/.pom/.jar}                                                 \
+            -Dsources=${pom/.pom/-sources.jar}                                      \
+            -Djavadoc=${pom/.pom/-javadoc.jar}
+    done
+}
 
+deploy_central() {
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo " Deploying and closing repository..."
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo " Deploying and closing repository..."
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    staging_output="${workdir}/deploy-output.txt"
+    $mvn --settings=${mvn_settings}                                                    \
+        org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository \
+        -DrepositoryDirectory=${staging}                                               \
+        -DnexusUrl=${MAVEN_ENDPOINT:-https://oss.sonatype.org}                         \
+        -DserverId=${server_id}                                                        \
+        -DautoReleaseAfterClose=true                                                   \
+        -DstagingProfileId=${MAVEN_STAGING_PROFILE_ID} | tee ${staging_output}
 
-staging_output="${workdir}/deploy-output.txt"
-$mvn --settings=${mvn_settings}                                                    \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository \
-    -DrepositoryDirectory=${staging}                                               \
-    -DnexusUrl=${MAVEN_ENDPOINT:-https://oss.sonatype.org}                                            \
-    -DserverId=ossrh                                                               \
-    -DautoReleaseAfterClose=true                                                   \
-    -DstagingProfileId=${MAVEN_STAGING_PROFILE_ID} | tee ${staging_output}
+    # we need to consule PIPESTATUS sinec "tee" is the last command
+    if [ ${PIPESTATUS[0]} -ne 0 ]; then
+        error "Repository deployment failed"
+    fi
 
-# we need to consule PIPESTATUS sinec "tee" is the last command
-if [ ${PIPESTATUS[0]} -ne 0 ]; then
-    echo "❌ Repository deployment failed"
-    exit 1
-fi
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo " Releasing repository"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo " Releasing repository"
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    # Extract the ID of the closed repository from the log output of "deploy-staged-repository"
+    # This is because "deploy-staged-repository" doesn't seem to support autoReleaseAfterClose
+    # See https://issues.sonatype.org/browse/OSSRH-42487
+    if $dry_run; then
+        echo 'Closing staging repository with ID "dummyrepo"' > ${staging_output}
+    fi
 
-# Extract the ID of the closed repository from the log output of "deploy-staged-repository"
-# This is because "deploy-staged-repository" doesn't seem to support autoReleaseAfterClose
-# See https://issues.sonatype.org/browse/OSSRH-42487
-if $dry_run; then
-    echo 'Closing staging repository with ID "dummyrepo"' > ${staging_output}
-fi
+    repository_id="$(cat ${staging_output} | grep "Closing staging repository with ID" | cut -d'"' -f2)"
+    if [ -z "${repository_id}" ]; then
+        echo "❌ Unable to extract repository ID from deploy-staged-repository output."
+        echo "This means it failed to close or there was an unexpected problem."
+        echo "At any rate, we can't release it. Sorry"
+        exit 1
+    fi
 
-repository_id="$(cat ${staging_output} | grep "Closing staging repository with ID" | cut -d'"' -f2)"
-if [ -z "${repository_id}" ]; then
-    echo "❌ Unable to extract repository ID from deploy-staged-repository output."
-    echo "This means it failed to close or there was an unexpected problem."
-    echo "At any rate, we can't release it. Sorry"
-    exit 1
-fi
+    echo "Repository ID: ${repository_id}"
 
-echo "Repository ID: ${repository_id}"
-
-# Create a dummy pom.xml because the "release" goal needs one, but it doesn't care about it at all
-release_pom="${workdir}/release-pom.xml"
-cat > ${release_pom} <<HERE
+    # Create a dummy pom.xml because the "release" goal needs one, but it doesn't care about it at all
+    release_pom="${workdir}/release-pom.xml"
+    cat > ${release_pom} <<HERE
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -193,27 +224,110 @@ cat > ${release_pom} <<HERE
 </project>
 HERE
 
-# Release!
-release_output="${workdir}/release-output.txt"
-$mvn --settings ${mvn_settings} -f ${release_pom} \
-    org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:release \
-    -DserverId=ossrh \
-    -DnexusUrl=${MAVEN_ENDPOINT:-https://oss.sonatype.org} \
-    -DstagingProfileId=${MAVEN_STAGING_PROFILE_ID} \
-    -DstagingRepositoryId=${repository_id} | tee ${release_output}
+    # Release!
+    release_output="${workdir}/release-output.txt"
+    $mvn --settings ${mvn_settings} -f ${release_pom}                 \
+        org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:release \
+        -DserverId=${server_id}                                       \
+        -DnexusUrl=${MAVEN_ENDPOINT:-https://oss.sonatype.org}        \
+        -DstagingProfileId=${MAVEN_STAGING_PROFILE_ID}                \
+        -DstagingRepositoryId=${repository_id} | tee ${release_output}
 
-# If release failed, check if this was caused because we are trying to publish
-# the same version again, which is not an error. The magic string "does not
-# allow updating artifact" for a ".pom" file indicates that we are trying to
-# override an existing version. Otherwise, fail!
-if [ ${PIPESTATUS[0]} -ne 0 ]; then
-    if cat ${release_output} | grep "does not allow updating artifact" | grep -q ".pom"; then
-        echo "⚠️ Artifact already published. Skipping"
-    else
-        echo "❌ Release failed"
-        exit 1
+    # If release failed, check if this was caused because we are trying to publish
+    # the same version again, which is not an error. The magic string "does not
+    # allow updating artifact" for a ".pom" file indicates that we are trying to
+    # override an existing version. Otherwise, fail!
+    if [ ${PIPESTATUS[0]} -ne 0 ]; then
+        if cat ${release_output} | grep "does not allow updating artifact" | grep -q ".pom"; then
+            echo "⚠️ Artifact already published. Skipping"
+        else
+            error "Release failed"
+        fi
     fi
-fi
+}
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "✅ All Done!"
+deploy_non_central() {
+    release_output="${workdir}/release-output.txt"
+    for pom in ${poms}; do
+        $mvn --settings=${mvn_settings} deploy -f ${pom} -DaltDeploymentRepository=${server_id}::default::${MAVEN_REPOSITORY_URL} | tee ${release_output}
+
+        # If release failed, check if this was caused because we are trying to publish
+        # the same version again, which is not an error. The magic string "409 Conflict"
+        # indicates that we are trying to
+        # override an existing version. Otherwise, fail!
+        if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            if cat ${release_output} | grep -q "409 Conflict"; then
+                echo "⚠️ Artifact already published. Skipping"
+            else
+                error "Release failed"
+            fi
+        fi
+    done
+}
+
+main() {
+    cd "${1:-"dist/java"}"
+
+    server_id="${MAVEN_SERVER_ID:-"${CENTRAL_SERVER}"}"
+    if [[ "${server_id}" == "${CENTRAL_SERVER}" ]]; then
+        is_central=true
+    else
+        is_central=false
+    fi
+
+    if [[ -n "${MAVEN_GPG_PRIVATE_KEY_FILE:-}" ]] || [[ -n "${MAVEN_GPG_PRIVATE_KEY:-}" ]]; then
+        is_signed=true
+    else
+        is_signed=false
+    fi
+
+    validate_parameters
+
+    if [[ -n "${MAVEN_DRYRUN:-}" ]]; then
+        echo "==========================================="
+        echo "            🏜️ DRY-RUN MODE 🏜️"
+        echo "==========================================="
+        mvn="echo mvn"
+        dry_run=true
+    else
+        mvn=mvn
+        dry_run=false
+    fi
+
+    if [[ "${is_signed}" == true ]]; then
+        import_gpg_key
+    fi
+
+    poms="$(find . -name '*.pom')"
+    if [ -z "${poms}" ]; then
+        error "No JARS to publish: no .pom files found under $PWD"
+    fi
+
+    if [[ "${is_central}" == true ]]; then
+        echo "📦 Publishing to Maven Central"
+    else
+        echo "📦 Publishing to ${server_id}"
+    fi
+    
+    staging=$(mktemp -d)
+    workdir=$(mktemp -d)
+    echo ${workdir}
+
+    create_maven_settings
+
+    if [[ "${is_signed}" == true ]]; then
+        # This currently only works with Maven Central
+        sign_artifacts
+    fi
+
+    if [[ "${is_central}" == true ]]; then
+        deploy_central
+    else
+        deploy_non_central
+    fi
+
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "✅ All Done!"
+}
+
+main "$@"; exit

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -68,13 +68,13 @@ validate_parameters() {
     [[ -z "${MAVEN_USERNAME:-}" ]] && error "MAVEN_USERNAME is required"
     [[ -z "${MAVEN_PASSWORD:-}" ]] && error "MAVEN_PASSWORD is required"
 
-    if [[ "${is_central}" == true ]]; then
+    if ${is_central}; then
         validate_central_parameters
     else
         validate_non_central_parameters
     fi
 
-    if [[ "${is_signed}" == true ]] || [[ "${is_central}" == true ]]; then
+    if (${is_signed} || ${is_central}); then
         validate_signing_parameters
     fi
 }
@@ -115,7 +115,7 @@ import_gpg_key() {
 create_maven_settings() {
     # Create a settings.xml file with the user+password for maven
     mvn_settings="${workdir}/mvn-settings.xml"
-    if [[ "${is_signed}" == true ]]; then
+    if ${is_signed}; then
         cat > ${mvn_settings} <<-EOF
 <?xml version="1.0" encoding="UTF-8" ?>
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
@@ -296,7 +296,7 @@ main() {
         dry_run=false
     fi
 
-    if [[ "${is_signed}" == true ]]; then
+    if ${is_signed}; then
         import_gpg_key
     fi
 
@@ -305,7 +305,7 @@ main() {
         error "No JARS to publish: no .pom files found under $PWD"
     fi
 
-    if [[ "${is_central}" == true ]]; then
+    if ${is_central}; then
         echo "📦 Publishing to Maven Central"
     else
         echo "📦 Publishing to ${server_id}"
@@ -317,12 +317,12 @@ main() {
 
     create_maven_settings
 
-    if [[ "${is_signed}" == true ]]; then
+    if ${is_signed}; then
         # This currently only works with Maven Central
         sign_artifacts
     fi
 
-    if [[ "${is_central}" == true ]]; then
+    if ${is_central}; then
         deploy_central
     else
         deploy_non_central


### PR DESCRIPTION
Closes #11

- These restructures the maven release script to support non-nexus based repositories. In particular, a parallel execution path exists that simply uses the maven deploy plugin.
- At this particular time, signing is only supported for nexus repositories.
- The username, password, and gpg passphrase are also kept out of files and replaced with environment variable lookups.
- Did a bit of cleanup on error handling to route all single line errors through the `error` function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
