### PR TITLE
fix: maven release is broken

### DIFF
--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -182,7 +182,6 @@ sign_artifacts() {
             -DrepositoryId=${server_id}                                             \
             -Dgpg.homedir=${GNUPGHOME}                                              \
             -Dgpg.keyname=0x${gpg_key_id}                                           \
-            -Dgpg.executable="${scriptdir}/gpg-workaround.sh"                       \
             -DpomFile=${pom}                                                        \
             -Dfile=${pom/.pom/.jar}                                                 \
             -Dsources=${pom/.pom/-sources.jar}                                      \


### PR DESCRIPTION
A previous commit forgot to remove the relevant line from the maven release script 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
