### PR TITLE
fix: Incorrect artifacts deployed for non maven central

### DIFF
--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -266,7 +266,13 @@ HERE
 deploy_non_central() {
     release_output="${workdir}/release-output.txt"
     for pom in ${poms}; do
-        $mvn --settings=${mvn_settings} deploy -f ${pom} -DaltDeploymentRepository=${server_id}::default::${MAVEN_REPOSITORY_URL} | tee ${release_output}
+        $mvn --settings=${mvn_settings} deploy:deploy-file          \
+            -Durl=${MAVEN_REPOSITORY_URL}                           \
+            -DrepositoryId=${server_id}                             \
+            -Dfile=${pom/.pom/.jar}                                 \
+            -DpomFile=${pom}                                        \
+            -Dsources=${pom/.pom/-sources.jar}                      \
+            -Djavadoc=${pom/.pom/-javadoc.jar} | tee ${release_output}
 
         # If release failed, check if this was caused because we are trying to publish
         # the same version again, which is not an error. The magic string "409 Conflict"


### PR DESCRIPTION
Deploying maven artifacts to sources other than maven central (i.e. github) was resulting in incorrect artifacts.

I believe that despite using `deploy`, a build was being down with just some metadata.
Now it uses `deploy-file` and explicitly specifies all artifacts. I've done a test run all the way through using the artifacts in a different project with success.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
