### PR TITLE
feat(NuGet): Support NuGet GitHub Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ npx jsii-release-nuget [DIR]
 |Option|Required|Description|
 |------|--------|-----------|
 |`NUGET_API_KEY`|Required|[NuGet API Key](https://www.nuget.org/account/apikeys) with "Push" permissions|
+|`NUGET_SERVER`|Optional|NuGet Server URL (defaults to nuget.org)|
+
+**Publish to GitHub Packages**
+
+* Set `NUGET_SERVER` to `https://nuget.pkg.github.com/(`org or user`).
+* Set `NUGET_API_KEY` to a token with write packages permissions.
+* Make sure the repository url in the project file matches the org or user used for the server 
 
 ## PyPI
 
@@ -177,7 +184,7 @@ npx jsii-release-pypi [DIR]
 ## Roadmap
 
 - [X] GitHub Support: Maven
-- [ ] GitHub Support: NuGet
+- [X] GitHub Support: NuGet
 - [ ] CodeArtifact Support: Maven
 - [ ] CodeArtifact Support: NuGet
 - [ ] CodeArtifact Support: Python

--- a/bin/jsii-release-nuget
+++ b/bin/jsii-release-nuget
@@ -29,7 +29,7 @@ fi
 
 echo "Publishing NuGet packages..."
 
-nuget_source="https://api.nuget.org/v3/index.json"
+nuget_source="${NUGET_SERVER:-"https://api.nuget.org/v3/index.json"}"
 nuget_symbol_source="https://nuget.smbsrc.net/"
 
 log=$(mktemp -d)/log.txt
@@ -44,7 +44,7 @@ for package_dir in ${packages}; do
         [ -f "${nuget_package_base}.snupkg" ] || echo "⚠️ No symbols package was found!"
 
         # The .snupkg will be published at the same time as the .nupkg if both are in the current folder (which is the case)
-        dotnet nuget push $nuget_package_name -k ${NUGET_API_KEY} -s ${nuget_source} | tee ${log}
+        dotnet nuget push $nuget_package_name -k ${NUGET_API_KEY} -s ${nuget_source} --skip-duplicate | tee ${log}
         exit_code="${PIPESTATUS[0]}"
 
         # If push failed, check if this was caused because we are trying to publish

--- a/bin/jsii-release-nuget
+++ b/bin/jsii-release-nuget
@@ -44,13 +44,13 @@ for package_dir in ${packages}; do
         [ -f "${nuget_package_base}.snupkg" ] || echo "⚠️ No symbols package was found!"
 
         # The .snupkg will be published at the same time as the .nupkg if both are in the current folder (which is the case)
-        dotnet nuget push $nuget_package_name -k ${NUGET_API_KEY} -s ${nuget_source} --skip-duplicate | tee ${log}
+        dotnet nuget push $nuget_package_name -k ${NUGET_API_KEY} -s ${nuget_source} | tee ${log}
         exit_code="${PIPESTATUS[0]}"
 
         # If push failed, check if this was caused because we are trying to publish
         # the same version again, which is not an error by searching for a magic string in the log
         # ugly, yes!
-        if cat ${log} | grep -q "already exists and cannot be modified"; then
+        if cat ${log} | grep -q -e "already exists and cannot be modified" -e "409 (Conflict)"; then
             echo "⚠️ Artifact already published. Skipping"
         elif [ "${exit_code}" -ne 0 ]; then
             echo "❌ Release failed"


### PR DESCRIPTION
Two changes required.
1. Configurable `nuget_source` through `NUGET_SERVER` env var. Defaults to nuget.org
2. ~~Use `--skip-duplicate` option. Could also add additional error string checks, but seems better to use built-in support for ignoring conflicts.~~ Expand existing conflict check to work for GitHub. `skip-duplicate` seemed to work on nuget.org for the main package, but didn't work correctly for the symbols package.

I have tested new and conflict states on GitHub and nuget.org. Also using the package in a project.