### PR TITLE
fix(golang): Username not fully respected if contains spaces

### DIFF
--- a/bin/jsii-release-golang
+++ b/bin/jsii-release-golang
@@ -119,7 +119,7 @@ echo "Cloning target repository ${GITHUB_REPO}"
 git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git ${target_repo_dir}
 
 pushd ${target_repo_dir}
-git config user.name ${GIT_USER_NAME}
+git config user.name "${GIT_USER_NAME}"
 git config user.email ${GIT_USER_EMAIL}
 
 # checkout or create


### PR DESCRIPTION
`GIT_USER_NAME` may contain spaces, so it needs to be quoted. Currently it just uses the first word.