### PR TITLE
fix(golang): Repository are incorrectly tagged

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ npx jsii-release-golang [DIR]
 `DIR` is a directory where the golang modules are located (default is `dist/go`). Each subdirectory inside it
 must be a go module and contain a go.mod file. This directory is pushed as is to the repository root, overriding existing files.
 
+Note that the repository tags will be prefixed with the module name. If a repository contains multiple modules,
+the repository will have multiple tags for each version, each corresponding to a different module. Consumers of the module will need to specify this prefix in their `require` directives. For example, for a module called `my-module`:
+
+```go
+require (
+	github.com/<owner>/<repo>/my-module my-module/v2.1.1
+)
+```
+
 **Options (environment variables):**
 
 |Option|Required|Description|

--- a/bin/jsii-release-golang
+++ b/bin/jsii-release-golang
@@ -58,6 +58,7 @@ fi
 
 go_mod=""
 versions=("")
+modules=("")
 
 # make sure each directory has a go.mod file
 for subdir in $(find ${dir} -mindepth 1 -maxdepth 1 -type d)
@@ -67,6 +68,9 @@ do
   fi
   # pick one mod file to derive repository
   go_mod=${subdir}/go.mod
+
+  # collect module names since we need them for tag prefixes.
+  modules=(${modules[@]} $(basename ${subdir}))
 
   # collect versions if they exist. used both for validation and for default value.
   if [ -f ${subdir}/version ]; then
@@ -140,14 +144,19 @@ cp -r ${dir}/* .
 git add .
 git commit -m "${GIT_COMMIT_MESSAGE}"
 
-tag_name=v${VERSION}
-git tag -a ${tag_name} -m $VERSION
+for module in "${modules[@]}"; do
+  tag_name=${module}/v${VERSION}
+  git tag -a ${tag_name} -m ${tag_name}
+  if $dry_run; then
+    echo "Will create tag: ${tag_name}"
+  else
+    git push origin ${tag_name}
+  fi
+done
 
 if $dry_run; then
-  echo "Will create a tag: ${tag_name}"
   echo "Will push to branch: ${GIT_BRANCH}"
 else
-  git push origin ${tag_name}
   git push origin ${GIT_BRANCH}
 fi
 


### PR DESCRIPTION
Added a module prefix to the tag. Either this, or a major version subdirectory is necessary for modules with a major version higher than `1` - we opted to use tag prefixes.

https://research.swtch.com/vgo-module#multiple-module_repositories 

This means that if a repository has multiple modules, it will have multiple tags for each version.

### Example dry run:

```console
===========================================
            🏜️ DRY-RUN MODE 🏜️
===========================================
Cloning target repository aws/constructs-go
Cloning into '/var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/tmp.Rzb5CmkP/repo'...
remote: Enumerating objects: 53, done.
remote: Total 53 (delta 0), reused 0 (delta 0), pack-reused 53
Unpacking objects: 100% (53/53), done.
/var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/tmp.Rzb5CmkP/repo ~/dev/src/github.com/aws/constructs
Already on 'main'
Your branch is up to date with 'origin/main'.
Removing /var/folders/mb/5zx1h88x2891nhk4qpr6_zc8jcqzm6/T/tmp.Rzb5CmkP/repo/constructs
Copying go modules to repository root
[main 886b5aa] chore(release): 1.1.0
 7 files changed, 3269 insertions(+), 3683 deletions(-)
 rewrite constructs/jsii/tarball.embedded.go (95%)
 delete mode 100644 constructs/local.go.sum
Will create tag: constructs/v1.1.0
Will push to branch: main
~/dev/src/github.com/aws/constructs
```